### PR TITLE
Removed Node 0.10 and added Node 6.9 to the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - mongodb
   - docker
 node_js:
-  - "0.10"
+  - "6.9.1"
   - "4.4.3"
 before_install:
   - npm install fh-build -g


### PR DESCRIPTION
# Motivation
Node 0.10 is not required anymore

# Changes
Removed Node 0.10 from the build and replaced with Node 6.9